### PR TITLE
Ridge 2.0.1

### DIFF
--- a/Tests/RidgeGeneratorInProcessTests/RidgeGeneratorInProcessTests.csproj
+++ b/Tests/RidgeGeneratorInProcessTests/RidgeGeneratorInProcessTests.csproj
@@ -10,8 +10,8 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" Condition="'$(TargetFramework)' == 'net6'"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7'"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.3.1"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.4.0"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0"/>
         <PackageReference Include="nunit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2"/>

--- a/Tests/RidgeGeneratorInProcessTests/SourceGeneratorInProcessTests.cs
+++ b/Tests/RidgeGeneratorInProcessTests/SourceGeneratorInProcessTests.cs
@@ -28,7 +28,7 @@ public class SourceGeneratorInProcessTests
                     [Ridge.AspNetCore.GeneratorAttributes.AddParameterToClient(typeof(int), "addedParameterZ", Ridge.AspNetCore.GeneratorAttributes.ParameterMapping.None, Op)]
                     [Ridge.AspNetCore.GeneratorAttributes.AddParameterToClient(typeof(int), "addedParameterX", Ridge.AspNetCore.GeneratorAttributes.ParameterMapping.None, Optional = fae)]
                     [Ridge.AspNetCore.GeneratorAttributes.AddParameterToClient(typeof(int), "addedParameterY", Ridge.AspNetCore.GeneratorAttributes.ParameterMapping.None, Optional = fae)
-                    [GenerateClient()]
+                    [Ridge.AspNetCore.GeneratorAttributes.GenerateClient()]
                     public class Test
                     {
                         public MethodWithoutReturn(){}

--- a/Tests/RidgeTests/DefaultCustomParametersAndTransformationsTests.cs
+++ b/Tests/RidgeTests/DefaultCustomParametersAndTransformationsTests.cs
@@ -35,12 +35,14 @@ public class ParametersAddedOrTransformedAutoMappingTests
             TransformedParametersWithDefaultMappingController.TestEnum.None,
             "route",
             10,
-            2.3);
+            2.3,
+            "CZ");
 
         response.Result.fromRouteParameter.Should().Be("route");
         response.Result.fromQueryParameter.Should().Be(TransformedParametersWithDefaultMappingController.TestEnum.None);
         response.Result.body.Should().Be(2.3);
         response.Result.fromHeaderParameter.Should().Be(10);
+        response.Result.parameterWithNameFromTransformer.Should().Be("CZ");
     }
 
     internal static Application CreateApplication()

--- a/Tests/RidgeTests/RidgeTests.csproj
+++ b/Tests/RidgeTests/RidgeTests.csproj
@@ -11,14 +11,11 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.11" Condition="'$(TargetFramework)' == 'net6'" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7'" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.3.1" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" />
         <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Verify.NUnit" Version="18.0.0" />
         <PackageReference Include="Verify.SourceGenerators" Version="2.0.0" />
-
     </ItemGroup>
 
     <ItemGroup>

--- a/Tests/TestWebApplication/Controllers/TransformedParametersWithDefaultMappingController.cs
+++ b/Tests/TestWebApplication/Controllers/TransformedParametersWithDefaultMappingController.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Ridge.AspNetCore.GeneratorAttributes;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace TestWebApplication.Controllers;
@@ -8,21 +10,48 @@ namespace TestWebApplication.Controllers;
 [TransformActionParameter(typeof(string), typeof(string), ParameterMapping.MapToQueryOrRouteParameter)]
 [TransformActionParameter(typeof(TestEnum), typeof(TestEnum), ParameterMapping.MapToQueryOrRouteParameter)]
 [TransformActionParameter(typeof(int), typeof(int), ParameterMapping.MapToHeader)]
+[TransformActionParameter(typeof(CountryCode), typeof(string), ParameterMapping.MapToHeader, GeneratedParameterName = "countryCode")]
 [TransformActionParameter(typeof(double), typeof(double), ParameterMapping.MapToBody)]
 public class TransformedParametersWithDefaultMappingController : ControllerBase
 {
     [HttpGet("transformation/{route}")]
-    public Task<ActionResult<(string fromRouteParameter, TestEnum fromQueryParameter, double body, int fromHeaderParameter)>> DefaultAction(
+    public Task<ActionResult<(string fromRouteParameter, TestEnum fromQueryParameter, double body, int fromHeaderParameter, string parameterWithNameFromTransformer)>> DefaultAction(
         [FromQuery] TestEnum query,
         [FromRoute] string route,
         [FromHeader] int header,
-        [FromBody] double body)
+        [FromBody] double body, 
+        [ModelBinder(typeof(BindCountryCodeFromQueryOrHeader))] CountryCode country)
     {
-        return Task.FromResult<ActionResult<(string fromRouteParameter, TestEnum fromQueryParameter, double body, int fromHeaderParameter)>>((route, query, body, header));
+        return Task.FromResult<ActionResult<(string fromRouteParameter, TestEnum fromQueryParameter, double body, int fromHeaderParameter, string parameterWithNameFromTransformer)>>((route, query, body, header, country.Value));
     }
 
     public enum TestEnum
     {
         None = 0,
+    }
+    
+    public class BindCountryCodeFromQueryOrHeader : IModelBinder
+    {
+        public Task BindModelAsync(
+            ModelBindingContext bindingContext)
+        {
+            // Get value from query or header
+            var str = bindingContext.ActionContext.HttpContext.Request.Headers["countryCode"].FirstOrDefault() ??
+                      bindingContext.ActionContext.HttpContext.Request.Query["countryCode"].FirstOrDefault();
+
+            bindingContext.Result = ModelBindingResult.Success(str == null ? null : new CountryCode(str));
+            return Task.CompletedTask;
+        }
+    }
+    
+    public class CountryCode
+    {
+        public string Value { get; }
+
+        public CountryCode(
+            string value)
+        {
+            Value = value;
+        }
     }
 }

--- a/src/Ridge/HttpRequestFactoryMiddlewares/Internal/ParameterAnalyzer.cs
+++ b/src/Ridge/HttpRequestFactoryMiddlewares/Internal/ParameterAnalyzer.cs
@@ -11,9 +11,20 @@ internal static class ParameterAnalyzer
     public static string GetAttributeNamePropertyOrParameterName(
         ActionAndClientParameterLinked actionAndClientParameterLinked)
     {
-        if (actionAndClientParameterLinked.ActionParameter == null)
+        // if parameter was added
+        if (!actionAndClientParameterLinked.DoesParameterExistInAction())
         {
-            return actionAndClientParameterLinked.ClientParameter!.Name;
+            return actionAndClientParameterLinked.ClientParameter.Name;
+        }
+
+        // if parameter was transformed
+        if (actionAndClientParameterLinked.WasParameterAddedOrTransformed && actionAndClientParameterLinked.DoesParameterExistsInClient())
+        {
+            // Name was transformed using attribute
+            if (actionAndClientParameterLinked.ClientParameter.Name != actionAndClientParameterLinked.ActionParameter?.Name)
+            {
+                return actionAndClientParameterLinked.ClientParameter.Name;
+            } 
         }
 
         var parameter = actionAndClientParameterLinked.ActionParameter.ParameterInfo;

--- a/src/Ridge/Parameters/ActionAndClientParams/ActionAndClientParameterLinked.cs
+++ b/src/Ridge/Parameters/ActionAndClientParams/ActionAndClientParameterLinked.cs
@@ -1,5 +1,6 @@
 ﻿using Ridge.Parameters.ActionParams;
 using Ridge.Parameters.ClientParams;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Ridge.Parameters.ActionAndClientParams;
 
@@ -44,6 +45,8 @@ public class ActionAndClientParameterLinked
     ///     Parameter might not exist in action when it was added using source generator.
     /// </summary>
     /// <returns>True if parameter exists in action.</returns>
+    [MemberNotNullWhen(true, nameof(ActionParameter))]
+    [MemberNotNullWhen(false, nameof(ClientParameter))]
     public bool DoesParameterExistInAction()
     {
         return ActionParameter != null;
@@ -54,6 +57,8 @@ public class ActionAndClientParameterLinked
     ///     Parameter might not exist in client when it was removed using source generator.
     /// </summary>
     /// <returns>True if parameter exists in client.</returns>
+    [MemberNotNullWhen(true, nameof(ClientParameter))]
+    [MemberNotNullWhen(false, nameof(ActionParameter))]
     public bool DoesParameterExistsInClient()
     {
         return ClientParameter != null;

--- a/src/RidgeSourceGenerator/RidgeSourceGenerator.csproj
+++ b/src/RidgeSourceGenerator/RidgeSourceGenerator.csproj
@@ -13,8 +13,8 @@
 
     <!-- The following libraries include the source generator interfaces and types we need -->
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2" PrivateAssets="all"/>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all"/>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" PrivateAssets="all"/>
     </ItemGroup>
 
     <!-- This ensures the library will be packaged as a source generator when we use `dotnet pack` -->


### PR DESCRIPTION
When parameter was transformed using TransformActionParameterwith with GeneratedParameterName specified, the name in the client was not used.

Source generator incorrectly caching namespaces. This lead to problems when moving the controller to a different namespace.

Used new optimized roslyn Api (https://github.com/dotnet/roslyn/issues/54725)